### PR TITLE
Use `SymInterpretedFloat`s in `XExpr`

### DIFF
--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -57,6 +57,7 @@ library
                           , bimap         >= 0.3 && < 0.4
                           , bv-sized      >= 1.0.2 && < 1.1
                           , containers    >= 0.4 && < 0.7
+                          , data-binary-ieee754
                           , data-default  >= 0.7 && < 0.8
                           , directory     >= 1.3 && < 1.4
                           , filepath      >= 1.4.2 && < 1.5

--- a/copilot-theorem/src/Copilot/Theorem/What4.hs
+++ b/copilot-theorem/src/Copilot/Theorem/What4.hs
@@ -52,11 +52,12 @@ import qualified Copilot.Core.Expr as CE
 import qualified Copilot.Core.Spec as CS
 import qualified Copilot.Core.Type as CT
 
-import qualified What4.Config           as WC
-import qualified What4.Expr.Builder     as WB
-import qualified What4.Interface        as WI
-import qualified What4.Solver           as WS
-import qualified What4.Solver.DReal     as WS
+import qualified What4.Config                   as WC
+import qualified What4.Expr.Builder             as WB
+import qualified What4.Interface                as WI
+import qualified What4.InterpretedFloatingPoint as WFP
+import qualified What4.Solver                   as WS
+import qualified What4.Solver.DReal             as WS
 
 import Control.Monad.State
 import Data.Foldable (foldrM)
@@ -184,7 +185,7 @@ data BisimulationProofBundle sym =
 
 
 computeBisimulationProofBundle ::
-  WI.IsSymExprBuilder sym =>
+  WFP.IsInterpretedFloatSymExprBuilder sym =>
   sym ->
   [String] ->
   CS.Spec ->
@@ -209,7 +210,7 @@ computeBisimulationProofBundle sym properties spec =
 
 
 computeInitialStreamState ::
-  WI.IsSymExprBuilder sym =>
+  WFP.IsInterpretedFloatSymExprBuilder sym =>
   sym ->
   CS.Spec ->
   IO (BisimulationProofState sym)
@@ -221,7 +222,7 @@ computeInitialStreamState sym spec =
      return (BisimulationProofState xs)
 
 computePrestate ::
-  WI.IsSymExprBuilder sym =>
+  WFP.IsInterpretedFloatSymExprBuilder sym =>
   sym ->
   CS.Spec ->
   TransM sym (BisimulationProofState sym)
@@ -235,7 +236,7 @@ computePrestate sym spec =
      return (BisimulationProofState xs)
 
 computePoststate ::
-  WI.IsSymExprBuilder sym =>
+  WFP.IsInterpretedFloatSymExprBuilder sym =>
   sym ->
   CS.Spec ->
   TransM sym (BisimulationProofState sym)
@@ -249,7 +250,7 @@ computePoststate sym spec =
      return (BisimulationProofState xs)
 
 computeTriggerState ::
-  WI.IsSymExprBuilder sym =>
+  WFP.IsInterpretedFloatSymExprBuilder sym =>
   sym ->
   CS.Spec ->
   TransM sym [(CE.Name, WI.Pred sym, [(Some CT.Type, XExpr sym)])]
@@ -266,7 +267,7 @@ computeTriggerState sym spec = forM (CS.specTriggers spec) $
         return (Some tp, v)
 
 computeExternalInputs ::
-  WI.IsSymExprBuilder sym =>
+  WFP.IsInterpretedFloatSymExprBuilder sym =>
   sym ->
   TransM sym [(CE.Name, Some CT.Type, XExpr sym)]
 computeExternalInputs sym =
@@ -276,7 +277,7 @@ computeExternalInputs sym =
           return (nm, Some tp, v)
 
 computeAssumptions ::
-  WI.IsSymExprBuilder sym =>
+  WFP.IsInterpretedFloatSymExprBuilder sym =>
   sym ->
   [String] ->
   CS.Spec ->


### PR DESCRIPTION
Previously, the `XFloat` and `XDouble` constructors of `XExpr` were using IEEE-754 representations of floating-point numbers. However, this doesn't mesh well with our current plans for `copilot-verifier`, in which we want to use uninterpreted floats. To fix this, we instead of `SymInterpretedFloat`s that are polymorphic over the particular What4 representation of floating-point numbers. This involves a fair amount of downstream code churn, but for the most part, this is mechanical.

This is one step towards GaloisInc/copilot-verifier#3.