### PR TITLE
Codegen fixes for structs

### DIFF
--- a/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
@@ -172,8 +172,8 @@ exprtypes e = case e of
 -- | List all types of a type, returns items uniquely.
 typetypes :: Typeable a => Type a -> [UType]
 typetypes ty = case ty of
-  Array ty' -> [UType ty] `union` typetypes ty'
-  Struct x  -> [UType ty] `union` map (\(Value ty' _) -> UType ty') (toValues x)
+  Array ty' -> typetypes ty' `union` [UType ty]
+  Struct x  -> concatMap (\(Value ty' _) -> typetypes ty') (toValues x) `union` [UType ty]
   _         -> [UType ty]
 
 -- | Collect all expression of a list of streams and triggers and wrap them

--- a/copilot-c99/src/Copilot/Compile/C99/Compile/Internal.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Compile/Internal.hs
@@ -142,7 +142,11 @@ compileh cSettings spec = C.TransUnit declns [] where
     extfundecln (Trigger name _ args) = C.FunDecln Nothing cty name params where
         cty    = C.TypeSpec C.Void
         params = map mkparam $ zip (argnames name) args
-        mkparam (name, UExpr ty _) = C.Param (transtype ty) name
+        mkparam (name, UExpr ty _) = C.Param (mkparamty ty) name
+
+        mkparamty ty = case ty of
+          Struct _ -> C.Const (C.Ptr (transtype ty))
+          _        -> transtype ty
 
   -- Declaration for the step function.
   stepdecln :: C.Decln

--- a/copilot-c99/src/Copilot/Compile/C99/Util.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Util.hs
@@ -55,9 +55,17 @@ guardname name = name ++ "_guard"
 argname :: String -> Int -> String
 argname name n = name ++ "_arg" ++ show n
 
+-- | Turn a trigger name into a name for a temporary variable for a trigger argument.
+argtempname :: String -> Int -> String
+argtempname name n = name ++ "_argtemp" ++ show n
+
 -- | Enumerate all argument names based on trigger name.
 argnames :: String -> [String]
 argnames base = [aname | n <- [0..], let aname = argname base n]
+
+-- | Enumerate all temporary variable names based on trigger name.
+argtempnames :: String -> [String]
+argtempnames base = [atempname | n <- [0..], let atempname = argtempname base n]
 
 -- | Define a C expression that calls a function with arguments.
 funcall :: C.Ident -> [C.Expr] -> C.Expr


### PR DESCRIPTION
This contains two commits needed to make it possible to verify generated code involving structs. Their commit messages are provided below.

## Make `C.Compile.C99.CodeGen.typetypes` return types in dependency order

Without this, Copilot programs involving nested structs had the potential to omit struct declarations if their types weren't directly mentioned in a trigger. The fix is simple—make `typetypes` recurse into struct types to make sure that nested struct types are also handled. While I was in town, I also did the same thing for array types. I don't have a program on hand involving arrays that exhibits the same buggy behavior, but it seems best to be consistent in our treatment of structs and arrays.

This is a workaround for Copilot-Language#275. This is needed in order to verify examples involving nested structs—see GaloisInc/copilot-verifier#9.

## Make struct arguments pointers in trigger functions

This is a design choice that I have adopted for the purpose of making the LLVM bitcode that Clang generates easier to analyze. The issue is that if you have a trigger function like this:

```c
void trigger(struct s ss) { ... }
```

The resulting LLVM bitcode will likely look very different from the source C code, since LLVM does a fair bit of transformation to fit the fields of `struct s` into a form that complies with the System V ABI. For more discussion on this point, see GaloisInc/copilot-verifier#9.

We can bypass this issue entirely by making trigger functions pass structs by reference, not by value. That is, do this:

```c
void trigger(const struct s *ss) { ... }
```

Clang compiles a C struct pointer directly to an LLVM struct pointer, which makes it much easier to deal with in a consistent manner.