### PR TITLE
Track side conditions in `translateExpr`

### DIFF
--- a/copilot-theorem/src/Copilot/Theorem/What4.hs
+++ b/copilot-theorem/src/Copilot/Theorem/What4.hs
@@ -180,6 +180,7 @@ data BisimulationProofBundle sym =
   , externalInputs     :: [(CE.Name, Some CT.Type, XExpr sym)]
   , triggerState       :: [(CE.Name, WI.Pred sym, [(Some CT.Type, XExpr sym)])]
   , assumptions        :: [WI.Pred sym]
+  , sideConds          :: [WI.Pred sym]
   }
 
 
@@ -197,6 +198,7 @@ computeBisimulationProofBundle sym properties spec =
           triggers  <- computeTriggerState sym spec
           assms     <- computeAssumptions sym properties spec
           externs   <- computeExternalInputs sym
+          sideCnds  <- gets sidePreds
           return
             BisimulationProofBundle
             { initialStreamState = iss
@@ -205,6 +207,7 @@ computeBisimulationProofBundle sym properties spec =
             , externalInputs  = externs
             , triggerState    = triggers
             , assumptions     = assms
+            , sideConds       = sideCnds
             }
 
 


### PR DESCRIPTION
Some operations can be partial, such as `Div`. We would like to track the conditions under which these operations are well defined such we can check if the corresponding partial operations in `copilot-c99`–generated code are also well defined. For instance, `Div` is only well defined if the second argument is not zero, so we record this as a `Pred` and track it in `TransM`'s state. We track similar side conditions for things like arithmetic overflow and out-out-bounds array indexing.

One thing we currently do not track are side conditions for floating-point operations (e.g., `Fdiv`). See `Note [Side conditions for floating-point operations]`. In case we wish to revisit this, I have added comments next to each floatin-point operation describing the circumstances under which they can be partial.

A prerequisite for GaloisInc/copilot-verifier#20.